### PR TITLE
Compact AMT nodes

### DIFF
--- a/hello_world.cpp
+++ b/hello_world.cpp
@@ -86,5 +86,8 @@ int main() {
   trie.insert("ad", 3);
   trie.contains("ad", 3);
 
+  trie.insert("ar", 3);
+  trie.contains("ar", 3);
+
   return 0;
 }

--- a/hello_world.cpp
+++ b/hello_world.cpp
@@ -72,7 +72,7 @@ int main() {
   assert(map.get(255));
 
   printf("Testing amt\n");
-  BitMappedNode trie;
+  ArrayMappedTrie trie;
 
   trie.insert("a", 2);
   assert(trie.contains("a", 2));

--- a/include/amt.hpp
+++ b/include/amt.hpp
@@ -15,7 +15,7 @@ class ArrayMappedTrie {
   std::vector<AMTNode> nodes;
 
   public:
-    ArrayMappedTrie();
+    ArrayMappedTrie(): map(NULL) {};
     void insert(const void *value, size_t len);
     bool contains(const void *value, size_t len);
 
@@ -30,10 +30,6 @@ class AMTNode {
     AMTNode(char c): character(c), sub_trie(NULL) {}
     AMTNode *next(char c);
 };
-
-ArrayMappedTrie::ArrayMappedTrie(): map(NULL) {
-  nodes.push_back(AMTNode('\0'));
-}
 
 AMTNode *AMTNode::next(char c) {
   if (!sub_trie) return NULL;
@@ -54,6 +50,8 @@ AMTNode *AMTNode::next(char c) {
 }
 
 bool ArrayMappedTrie::contains(const void *value, size_t len) {
+  if (!nodes.size()) return false;
+
   int i;
   AMTNode *node = &nodes[0];
   unsigned char *c = (unsigned char *) value;
@@ -68,6 +66,10 @@ bool ArrayMappedTrie::contains(const void *value, size_t len) {
 void ArrayMappedTrie::insert(const void *value, size_t len) {
   int i;
   unsigned char *c = (unsigned char *) value;
+
+  if (!nodes.size())
+    nodes.push_back(AMTNode('\0'));
+
   AMTNode *node = &nodes[0];
 
   for (i = 0; i < len; ++i, ++c) {
@@ -88,8 +90,14 @@ void ArrayMappedTrie::insert(const void *value, size_t len) {
       trie->map->set(*c, true);
       index = trie->map->get_offset(*c);
     } else {
-      AMTNode *tmp_node = &node_list->at(0);
-      for (index = 0; index < node_list->size() && tmp_node->character < *c; ++index, ++tmp_node);
+      index = 0;
+      if (!node_list->empty()) {
+        AMTNode *tmp_node = &node_list->at(0);
+        while (index < node_list->size() && tmp_node->character < *c) {
+          ++index;
+          ++tmp_node;
+        }
+      }
     }
 
     node_list->emplace(node_list->begin() + index, AMTNode(*c));
@@ -102,7 +110,6 @@ void ArrayMappedTrie::insert(const void *value, size_t len) {
 }
 
 void ArrayMappedTrie::add_bitmap() {
-  assert(false);
   map = new Bitmap();
   for (auto node : nodes)
     map->set(node.character, true);

--- a/include/amt.hpp
+++ b/include/amt.hpp
@@ -6,14 +6,14 @@
 
 class AMTNode;
 
-class BitMappedNode {
+class ArrayMappedTrie {
   friend class AMTNode;
 
-  Bitmap map;
+  Bitmap *map;
   std::vector<AMTNode> nodes;
 
   public:
-    BitMappedNode();
+    ArrayMappedTrie();
     void insert(const void *value, size_t len);
     bool contains(const void *value, size_t len);
 };
@@ -21,23 +21,23 @@ class BitMappedNode {
 class AMTNode {
   public:
     uint16_t character;
-    BitMappedNode *sub_trie;
+    ArrayMappedTrie *sub_trie;
     AMTNode(char c): character(c), sub_trie(NULL) {}
     AMTNode *next(char c);
 };
 
-BitMappedNode::BitMappedNode() {
+ArrayMappedTrie::ArrayMappedTrie(): map(new Bitmap()) {
   nodes.push_back(AMTNode('\0'));
 }
 
 AMTNode *AMTNode::next(char c) {
-  if (!sub_trie || !sub_trie->map.get(c)) return NULL;
-  int index = sub_trie->map.get_offset(c);
+  if (!sub_trie || !sub_trie->map->get(c)) return NULL;
+  int index = sub_trie->map->get_offset(c);
   AMTNode *node = &sub_trie->nodes[index];
   return node;
 }
 
-bool BitMappedNode::contains(const void *value, size_t len) {
+bool ArrayMappedTrie::contains(const void *value, size_t len) {
   int i;
   AMTNode *node = &nodes[0];
   unsigned char *c = (unsigned char *) value;
@@ -49,7 +49,7 @@ bool BitMappedNode::contains(const void *value, size_t len) {
   return true;
 }
 
-void BitMappedNode::insert(const void *value, size_t len) {
+void ArrayMappedTrie::insert(const void *value, size_t len) {
   int i;
   unsigned char *c = (unsigned char *) value;
   AMTNode *node = &nodes[0];
@@ -62,11 +62,11 @@ void BitMappedNode::insert(const void *value, size_t len) {
 
   for (; i < len; ++i, ++c) {
     if (!node->sub_trie)
-      node->sub_trie = new BitMappedNode();
+      node->sub_trie = new ArrayMappedTrie();
 
-    node->sub_trie->map.set(*c, true);
+    node->sub_trie->map->set(*c, true);
 
-    int index = node->sub_trie->map.get_offset(*c);
+    int index = node->sub_trie->map->get_offset(*c);
     std::vector<AMTNode> *node_list = &node->sub_trie->nodes;
     node_list->emplace(node_list->begin() + index, AMTNode(*c));
 

--- a/include/amt.hpp
+++ b/include/amt.hpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include "bit_map.hpp"
 
+const int MIN_BITMAPPED_SIZE = 5;
+
 class AMTNode;
 
 class ArrayMappedTrie {
@@ -16,6 +18,9 @@ class ArrayMappedTrie {
     ArrayMappedTrie();
     void insert(const void *value, size_t len);
     bool contains(const void *value, size_t len);
+
+  private:
+    void add_bitmap();
 };
 
 class AMTNode {
@@ -89,8 +94,18 @@ void ArrayMappedTrie::insert(const void *value, size_t len) {
 
     node_list->emplace(node_list->begin() + index, AMTNode(*c));
 
+    if (!trie->map && node_list->size() >= MIN_BITMAPPED_SIZE)
+      trie->add_bitmap();
+
     node = &node_list->at(index);
   }
+}
+
+void ArrayMappedTrie::add_bitmap() {
+  assert(false);
+  map = new Bitmap();
+  for (auto node : nodes)
+    map->set(node.character, true);
 }
 
 #endif


### PR DESCRIPTION
Each Bitmap adds an overhead of 64 bytes to each AMT node. To balance lookup speed with memory usage, nodes with fewer than 5 elements have no Bitmap and are read with a linear lookup. Nodes with 5 or more elements get a Bitmap for fast lookups.
