### PR TITLE
Split subtries into two new classes

### DIFF
--- a/amt.idl
+++ b/amt.idl
@@ -1,5 +1,5 @@
-interface ArrayMappedTrie {
-  void ArrayMappedTrie();
+interface Trie {
+  void Trie();
   void insert(DOMString str);
   boolean contains(DOMString str);
   unsigned long size();

--- a/include/amt.hpp
+++ b/include/amt.hpp
@@ -6,31 +6,74 @@
 
 const int MIN_BITMAPPED_SIZE = 5;
 
-class ArrayMappedTrie {
-
+class Trie {
   private:
+
+    class SubTrie;
+
     class AMTNode {
       public:
         uint16_t character;
-        std::unique_ptr<ArrayMappedTrie> sub_trie;
+        std::unique_ptr<Trie::SubTrie> sub_trie;
         AMTNode(char c): character(c), sub_trie(nullptr) {}
         AMTNode *next(char c);
         size_t sub_trie_size();
     };
 
-    Bitmap *map;
-    std::vector<ArrayMappedTrie::AMTNode> nodes;
-    void add_bitmap();
+    class SubTrie {
+      public:
+        virtual Trie::AMTNode *next(char c) = 0;
+        virtual Trie::AMTNode *insert_node(char c) = 0;
+        std::vector<Trie::AMTNode> nodes;
+    };
+
+    class CompactTrie : public SubTrie {
+      public:
+        Trie::AMTNode *next(char c);
+        Trie::AMTNode *insert_node(char c);
+    };
+
+    class ArrayMappedTrie : public SubTrie {
+      public:
+        Bitmap map;
+        Trie::AMTNode *next(char c);
+        Trie::AMTNode *insert_node(char c);
+    };
+
+    //static ArrayMappedTrie *add_bitmap(std::unique_ptr<Trie::SubTrie> old);
+    static ArrayMappedTrie *add_bitmap(SubTrie *old);
+    CompactTrie root;
 
   public:
-    ArrayMappedTrie(): map(NULL) {};
+    //Trie::Trie() : root(NULL) {};
     void insert(const char *str);
     bool contains(const char *str);
     size_t size();
 
 };
 
-ArrayMappedTrie::AMTNode *ArrayMappedTrie::AMTNode::next(char c) {
+
+
+Trie::AMTNode *Trie::CompactTrie::next(char c) {
+  for (unsigned int index = 0; index < nodes.size(); ++index) {
+    AMTNode *node = &nodes[index];
+    if (node->character == c)
+      return node;
+    if (node->character > c)
+      return NULL;
+  }
+  return NULL;
+}
+
+Trie::AMTNode *Trie::ArrayMappedTrie::next(char c) {
+  if (!map.get(c)) return NULL;
+  int index = map.get_offset(c);
+  return &nodes[index];
+}
+
+Trie::AMTNode *Trie::AMTNode::next(char c) {
+  return sub_trie ? sub_trie->next(c) : NULL;
+  /*
   if (!sub_trie) return NULL;
 
   unsigned int index;
@@ -48,12 +91,13 @@ ArrayMappedTrie::AMTNode *ArrayMappedTrie::AMTNode::next(char c) {
     }
     return NULL;
   }
+  */
 }
 
-bool ArrayMappedTrie::contains(const char *str) {
-  if (!nodes.size()) return false;
+bool Trie::contains(const char *str) {
+  if (!root.nodes.size()) return false;
 
-  AMTNode *node = &nodes[0];
+  AMTNode *node = &root.nodes[0];
 
   for (; *str; ++str) {
     if (!node) return false;
@@ -62,13 +106,32 @@ bool ArrayMappedTrie::contains(const char *str) {
   return node->next('\0') != NULL;
 }
 
-void ArrayMappedTrie::insert(const char *str) {
+Trie::AMTNode *Trie::CompactTrie::insert_node(char c) {
+  unsigned int index = 0;
+  size_t sz = nodes.size();
+  for (; index < sz; ++index) {
+    if (nodes.at(index).character > c)
+      break;
+  }
+
+  nodes.emplace(nodes.begin() + index, AMTNode(c));
+  return &nodes.at(index);
+}
+
+Trie::AMTNode *Trie::ArrayMappedTrie::insert_node(char c) {
+  map.set(c, true);
+  int index = map.get_offset(c);
+  nodes.emplace(nodes.begin() + index, AMTNode(c));
+  return &nodes.at(index);
+}
+
+void Trie::insert(const char *str) {
   char *c = (char *) str;
 
-  if (!nodes.size())
-    nodes.push_back(AMTNode('\0'));
+  if (!root.nodes.size())
+    root.nodes.push_back(AMTNode('\0'));
 
-  AMTNode *node = &nodes[0];
+  AMTNode *node = &root.nodes[0];
 
   for (; *c; ++c) {
     AMTNode *tmp = node->next(*c);
@@ -81,11 +144,12 @@ void ArrayMappedTrie::insert(const char *str) {
 
   for (i = 0; i < size; ++i, ++c) {
     if (!node->sub_trie) {
-      node->sub_trie.reset(new ArrayMappedTrie());
+      node->sub_trie.reset(new CompactTrie());
     }
 
     std::vector<AMTNode> *node_list = &node->sub_trie->nodes;
 
+    /*
     unsigned int index;
     if (node->sub_trie->map) {
       node->sub_trie->map->set(*c, true);
@@ -97,27 +161,36 @@ void ArrayMappedTrie::insert(const char *str) {
           break;
       }
     }
-
     node_list->emplace(node_list->begin() + index, AMTNode(*c));
+    */
+    auto tmp_node = node->sub_trie->insert_node(*c);
 
+    if (node_list->size() == MIN_BITMAPPED_SIZE) {
+      node->sub_trie.reset(add_bitmap(node->sub_trie.get()));
+    }
+    
+    node = tmp_node;
+
+    /*
     if (!node->sub_trie->map && node_list->size() >= MIN_BITMAPPED_SIZE)
       node->sub_trie->add_bitmap();
+    */
 
-    node = &node_list->at(index);
+    //node = &node_list->at(index);
   }
 }
 
-size_t ArrayMappedTrie::size() {
-  if (nodes.empty()) {
+size_t Trie::size() {
+  if (root.nodes.empty()) {
     return 0;
   } else {
-    AMTNode *root = &nodes[0];
-    assert(root->sub_trie);
-    return root->sub_trie_size();
+    //AMTNode *root = &nodes[0];
+    assert(root.nodes[0].sub_trie);
+    return root.nodes[0].sub_trie_size();
   }
 }
 
-size_t ArrayMappedTrie::AMTNode::sub_trie_size() {
+size_t Trie::AMTNode::sub_trie_size() {
   assert(sub_trie);
   size_t total = 0, sz = sub_trie->nodes.size();
   for (unsigned int i = 0; i < sz; ++i) {
@@ -130,11 +203,24 @@ size_t ArrayMappedTrie::AMTNode::sub_trie_size() {
   return total;
 }
 
-void ArrayMappedTrie::add_bitmap() {
+Trie::ArrayMappedTrie *Trie::add_bitmap(SubTrie *old) {
+  auto new_trie = new ArrayMappedTrie();
+  //new_trie->nodes.insert(new_trie->nodes.begin(), old->nodes.begin(), old->nodes.begin());
+  new_trie->nodes = old->nodes;
+
+  size_t sz = new_trie->nodes.size();
+  for (unsigned int i = 0; i < sz; ++i)
+    new_trie->map.set(new_trie->nodes.at(i).character, true);
+  return new_trie;
+}
+
+/*
+void Trie::add_bitmap() {
   map = new Bitmap();
   size_t sz = nodes.size();
   for (unsigned int i = 0; i < sz; ++i)
     map->set(nodes.at(i).character, true);
 }
+*/
 
 #endif

--- a/include/amt.hpp
+++ b/include/amt.hpp
@@ -24,7 +24,8 @@ class Trie {
       public:
         virtual Trie::AMTNode *next(char c) = 0;
         virtual Trie::AMTNode *insert_node(char c) = 0;
-        std::vector<Trie::AMTNode> nodes;
+        std::unique_ptr<std::vector<Trie::AMTNode>> nodes;
+        SubTrie() : nodes(new std::vector<Trie::AMTNode>) {};
     };
 
     class CompactTrie : public SubTrie {
@@ -40,23 +41,18 @@ class Trie {
         Trie::AMTNode *insert_node(char c);
     };
 
-    //static ArrayMappedTrie *add_bitmap(std::unique_ptr<Trie::SubTrie> old);
     static ArrayMappedTrie *add_bitmap(SubTrie *old);
     CompactTrie root;
 
   public:
-    //Trie::Trie() : root(NULL) {};
     void insert(const char *str);
     bool contains(const char *str);
     size_t size();
-
 };
 
-
-
 Trie::AMTNode *Trie::CompactTrie::next(char c) {
-  for (unsigned int index = 0; index < nodes.size(); ++index) {
-    AMTNode *node = &nodes[index];
+  for (unsigned int index = 0; index < nodes->size(); ++index) {
+    AMTNode *node = &nodes->at(index);
     if (node->character == c)
       return node;
     if (node->character > c)
@@ -68,36 +64,17 @@ Trie::AMTNode *Trie::CompactTrie::next(char c) {
 Trie::AMTNode *Trie::ArrayMappedTrie::next(char c) {
   if (!map.get(c)) return NULL;
   int index = map.get_offset(c);
-  return &nodes[index];
+  return &nodes->at(index);
 }
 
 Trie::AMTNode *Trie::AMTNode::next(char c) {
   return sub_trie ? sub_trie->next(c) : NULL;
-  /*
-  if (!sub_trie) return NULL;
-
-  unsigned int index;
-  if (sub_trie->map) {
-    if (!sub_trie->map->get(c)) return NULL;
-    index = sub_trie->map->get_offset(c);
-    return &sub_trie->nodes[index];
-  } else {
-    for (index = 0; index < sub_trie->nodes.size(); ++index) {
-      AMTNode *node = &sub_trie->nodes[index];
-      if (node->character == c)
-        return node;
-      if (node->character > c)
-        return NULL;
-    }
-    return NULL;
-  }
-  */
 }
 
 bool Trie::contains(const char *str) {
-  if (!root.nodes.size()) return false;
+  if (!root.nodes->size()) return false;
 
-  AMTNode *node = &root.nodes[0];
+  AMTNode *node = &root.nodes->at(0);
 
   for (; *str; ++str) {
     if (!node) return false;
@@ -108,30 +85,30 @@ bool Trie::contains(const char *str) {
 
 Trie::AMTNode *Trie::CompactTrie::insert_node(char c) {
   unsigned int index = 0;
-  size_t sz = nodes.size();
+  size_t sz = nodes->size();
   for (; index < sz; ++index) {
-    if (nodes.at(index).character > c)
+    if (nodes->at(index).character > c)
       break;
   }
 
-  nodes.emplace(nodes.begin() + index, AMTNode(c));
-  return &nodes.at(index);
+  nodes->emplace(nodes->begin() + index, AMTNode(c));
+  return &nodes->at(index);
 }
 
 Trie::AMTNode *Trie::ArrayMappedTrie::insert_node(char c) {
   map.set(c, true);
   int index = map.get_offset(c);
-  nodes.emplace(nodes.begin() + index, AMTNode(c));
-  return &nodes.at(index);
+  nodes->emplace(nodes->begin() + index, AMTNode(c));
+  return &nodes->at(index);
 }
 
 void Trie::insert(const char *str) {
   char *c = (char *) str;
 
-  if (!root.nodes.size())
-    root.nodes.push_back(AMTNode('\0'));
+  if (!root.nodes->size())
+    root.nodes->push_back(AMTNode('\0'));
 
-  AMTNode *node = &root.nodes[0];
+  AMTNode *node = &root.nodes->at(0);
 
   for (; *c; ++c) {
     AMTNode *tmp = node->next(*c);
@@ -140,61 +117,35 @@ void Trie::insert(const char *str) {
   }
 
   int size = strlen(str) + 1;
-  int i = 0;
 
-  for (i = 0; i < size; ++i, ++c) {
-    if (!node->sub_trie) {
+  for (int i = 0; i < size; ++i, ++c) {
+    if (!node->sub_trie)
       node->sub_trie.reset(new CompactTrie());
-    }
 
-    std::vector<AMTNode> *node_list = &node->sub_trie->nodes;
-
-    /*
-    unsigned int index;
-    if (node->sub_trie->map) {
-      node->sub_trie->map->set(*c, true);
-      index = node->sub_trie->map->get_offset(*c);
-    } else {
-      size_t sz = node_list->size();
-      for (index = 0; index < sz; ++index) {
-        if (node_list->at(index).character > *c)
-          break;
-      }
-    }
-    node_list->emplace(node_list->begin() + index, AMTNode(*c));
-    */
+    std::vector<AMTNode> *node_list = node->sub_trie->nodes.get();
     auto tmp_node = node->sub_trie->insert_node(*c);
 
-    if (node_list->size() == MIN_BITMAPPED_SIZE) {
+    if (node_list->size() == MIN_BITMAPPED_SIZE)
       node->sub_trie.reset(add_bitmap(node->sub_trie.get()));
-    }
     
     node = tmp_node;
-
-    /*
-    if (!node->sub_trie->map && node_list->size() >= MIN_BITMAPPED_SIZE)
-      node->sub_trie->add_bitmap();
-    */
-
-    //node = &node_list->at(index);
   }
 }
 
 size_t Trie::size() {
-  if (root.nodes.empty()) {
+  if (root.nodes->empty()) {
     return 0;
   } else {
-    //AMTNode *root = &nodes[0];
-    assert(root.nodes[0].sub_trie);
-    return root.nodes[0].sub_trie_size();
+    assert(root.nodes->at(0).sub_trie);
+    return root.nodes->at(0).sub_trie_size();
   }
 }
 
 size_t Trie::AMTNode::sub_trie_size() {
   assert(sub_trie);
-  size_t total = 0, sz = sub_trie->nodes.size();
+  size_t total = 0, sz = sub_trie->nodes->size();
   for (unsigned int i = 0; i < sz; ++i) {
-    auto node = &sub_trie->nodes.at(i);
+    auto node = &sub_trie->nodes->at(i);
     if (node->character == '\0')
       total++;
     else if (node->sub_trie)
@@ -205,22 +156,11 @@ size_t Trie::AMTNode::sub_trie_size() {
 
 Trie::ArrayMappedTrie *Trie::add_bitmap(SubTrie *old) {
   auto new_trie = new ArrayMappedTrie();
-  //new_trie->nodes.insert(new_trie->nodes.begin(), old->nodes.begin(), old->nodes.begin());
-  new_trie->nodes = old->nodes;
+  new_trie->nodes = std::move(old->nodes);
 
-  size_t sz = new_trie->nodes.size();
+  size_t sz = new_trie->nodes->size();
   for (unsigned int i = 0; i < sz; ++i)
-    new_trie->map.set(new_trie->nodes.at(i).character, true);
+    new_trie->map.set(new_trie->nodes->at(i).character, true);
   return new_trie;
 }
-
-/*
-void Trie::add_bitmap() {
-  map = new Bitmap();
-  size_t sz = nodes.size();
-  for (unsigned int i = 0; i < sz; ++i)
-    map->set(nodes.at(i).character, true);
-}
-*/
-
 #endif

--- a/include/amt.hpp
+++ b/include/amt.hpp
@@ -86,10 +86,9 @@ bool Trie::contains(const char *str) {
 Trie::AMTNode *Trie::CompactTrie::insert_node(char c) {
   unsigned int index = 0;
   size_t sz = nodes->size();
-  for (; index < sz; ++index) {
-    if (nodes->at(index).character > c)
-      break;
-  }
+
+  while (index < sz && nodes->at(index).character < c)
+    index++;
 
   nodes->emplace(nodes->begin() + index, AMTNode(c));
   return &nodes->at(index);

--- a/include/amt.hpp
+++ b/include/amt.hpp
@@ -121,13 +121,10 @@ void Trie::insert(const char *str) {
     if (!node->sub_trie)
       node->sub_trie.reset(new CompactTrie());
 
-    std::vector<AMTNode> *node_list = node->sub_trie->nodes.get();
-    auto tmp_node = node->sub_trie->insert_node(*c);
-
-    if (node_list->size() == MIN_BITMAPPED_SIZE)
+    if (node->sub_trie->nodes->size() == MIN_BITMAPPED_SIZE - 1)
       node->sub_trie.reset(add_bitmap(node->sub_trie.get()));
 
-    node = tmp_node;
+    node = node->sub_trie->insert_node(*c);
   }
 }
 

--- a/include/amt.hpp
+++ b/include/amt.hpp
@@ -1,6 +1,6 @@
 #ifndef AMT_H
 #define AMT_H
- 
+
 #include <vector>
 #include "bit_map.hpp"
 
@@ -127,7 +127,7 @@ void Trie::insert(const char *str) {
 
     if (node_list->size() == MIN_BITMAPPED_SIZE)
       node->sub_trie.reset(add_bitmap(node->sub_trie.get()));
-    
+
     node = tmp_node;
   }
 }

--- a/test-js/trie.js
+++ b/test-js/trie.js
@@ -4,7 +4,7 @@ var Module = require('../dist/amt.out.js');
 describe('Trie', function() {
   describe('size', function() {
     it('should be zero when initialized', function() {
-      var trie = new Module.ArrayMappedTrie();
+      var trie = new Module.Trie();
       assert.equal(trie.size(), 0);
     });
   });

--- a/test/trie.cpp
+++ b/test/trie.cpp
@@ -3,7 +3,7 @@
 #include "amt.hpp"
 
 TEST_CASE ("Strings with different prefixes can be inserted", "[trie]") {
-  ArrayMappedTrie trie;
+  Trie trie;
 
   trie.insert("a");
   REQUIRE( trie.contains("a") );
@@ -16,7 +16,7 @@ TEST_CASE ("Strings with different prefixes can be inserted", "[trie]") {
 }
 
 TEST_CASE ("Strings with common prefixes can be inserted", "[trie]") {
-  ArrayMappedTrie trie;
+  Trie trie;
 
   trie.insert("ag");
   REQUIRE ( trie.contains("ag") );
@@ -32,13 +32,13 @@ TEST_CASE ("Strings with common prefixes can be inserted", "[trie]") {
 }
 
 TEST_CASE ("Size begins at zero", "[trie]") {
-  ArrayMappedTrie trie;
+  Trie trie;
 
   REQUIRE ( trie.size() == 0 );
 }
 
 TEST_CASE ("Size increases upon insertion", "[trie]") {
-  ArrayMappedTrie trie;
+  Trie trie;
 
   trie.insert("a");
   REQUIRE ( trie.size() == 1 );

--- a/test/trie.cpp
+++ b/test/trie.cpp
@@ -29,6 +29,9 @@ TEST_CASE ("Strings with common prefixes can be inserted", "[trie]") {
 
   trie.insert("ar");
   REQUIRE ( trie.contains("ar") );
+
+  trie.insert("aa");
+  REQUIRE ( trie.contains("aa") );
 }
 
 TEST_CASE ("Size begins at zero", "[trie]") {


### PR DESCRIPTION
With common ancestor SubTrie.

This simplifies the logic of `Trie` methods so that it doesn't concern itself with whether a trie node has a Bitmap or not. It removes the unused Bitmap \* on non-bitmapped nodes. 
